### PR TITLE
Add terminology page

### DIFF
--- a/src/routes/docs/business-plan
+++ b/src/routes/docs/business-plan
@@ -1,0 +1,78 @@
+---
+title: Open Business Plans
+---
+
+Any open source project with the intention to commercialize its value creation should be able to answer this question: **How will you make money?**
+
+Seth Godin's "[The Modern Business Plan](https://seths.blog/2010/05/the-modern-business-plan/?ref=blog.meilisearch.com)" provides a very useful, prose-focused template that lends itself well to consumption by the general public. This is the v0.1 release of our *Open Business Plan*.
+
+> It’s not clear to me why business plans are the way they are, but they’re often misused to obfuscate, bore and show an ability to comply with expectations. If I want the real truth about a business and where it’s going, I’d rather see something else. I’d divide the modern business plan into five sections:
+>
+> **1. Truth**
+> **2. Assertions**
+> **3. Alternatives**
+> **4. People**
+> **5. Money**
+
+## Truth
+
+> The truth section describes the world as it is. Footnote if you want to, but tell me about the market you are entering, the needs that already exist, the competitors in your space, technology standards, the way others have succeeded and failed in the past. The more specific the better. The more ground knowledge the better. The more visceral the stories, the better. The point of this section is to be sure that you’re clear about the way you see the world, and that you and I agree on your assumptions. This section isn’t partisan, it takes no positions, it just states how things are. Truth can take as long as you need to tell it. It can include spreadsheets, market share analysis and anything I need to know about how the world works.
+
+Our current day communication tools are still so bad that we have to actively protect ourselves from them. If you don’t get your notifications set straight, chat/email/what-have-you will cause you [undue suffering](https://basecamp.com/guides/group-chat-problems).
+
+You shouldn’t have to learn how to protect yourself from your comms tool. Your comms tool should be like a decked out playground and a group of friends all bundled together. 
+
+The worst comms tools (Facebook, Reddit (Slack, Discord)) are trapped in late-stage capitalism games where data hoarding and user manipulation is incentivized.
+
+Even the best of the open source comms tools (Discourse, Mattermost, GitLab etc.) are not focused on serving the user segment that needs baseline service the most: individuals and grassroots communities; local-first.
+
+Commune won’t just be a better comms tool because it combines chat (synchronous, ephemeral) and forum (asynchronous, permanent) into one. It will be better because as both an application and a company, it is designed to work best for the marginalized.
+
+[Reclaiming my digital identity](https://blog.erlend.sh/reclaiming-my-digital-identity)
+[Communal Bonfires](https://blog.erlend.sh/communal-bonfires)
+
+## Assertion
+
+> The assertions section is your chance to describe how you’re going to change things. We will do X, and then Y will happen. We will build Z with this much money in this much time. We will present Q to the market and the market will respond by taking this action. This is the heart of the modern business plan. The only reason to launch a project is to change something, and I want to know what you’re going to do and what impact it’s going to have.
+
+Even though the chat space is beyond saturated by now, there is still a lack of privacy-respecting applications that are intuitive to use for non tech-savvy users, both individuals and businesses. 
+
+Matrix does a great job building a vision of how a well-designed encrypted and federated protocol can work, but the ambitiously standards-focused nature of the project prevents them from building an app that has a laser-like focus on user experience.
+
+We want Matrix to succeed because it's one of the remaining greybeard hacker projects that keeps true to the old internet spirit. Unless someone (like Commune) in the Matrix ecosystem is able to keep up with the UI/UX of proprietary apps AND innovate on new features, then the protocol will remain a fringe technology.
+
+Commune not only wants to build the "best" generic Matrix client with amazing user experience raising the bar for the ecosystem, but also innovate on novel features that centralized incumbents like Slack and Discord simply cannot replicate, e.g. by building "webrings" of affiliated communities and genuine public squares based on federation.
+
+[Assembling Community OS](https://blog.erlend.sh/assembling-community-os)
+
+### Service
+
+SaaS will be our initial focus as a company. It's the more proven model available to us, and the tech stack for self-hosting Matrix is still maturing (Conduit et.al.). But we won't build any exclusives into our offering; any feature we build for our SaaS offering will either be open source or source-available (i.e. freely available for non-commercial or equitable-commons use; purchasable license for commercial use).
+
+Eventually, customers will get to choose between the instant value of SaaS, or the full control of self-hosted.
+
+### Incentives for self-hosting
+
+We intend to structure our business in a way that incentivizes a continued investment in the self-hosting capabilities of Commune. Many open source companies with a SaaS offering end up with inverse incentives to continue improving their user-facing installation story because it competes with their SaaS business. By exploring fair ways to monetize our on-premise offering in commercial contexts we will ensure an ongoing equilibrium in our incentives.
+
+### Self-hosting as a self-negotiator on pricing
+
+A SaaS product that can be alternatively self-hosted with ease is inherently pricing-transparent. When discerning customers can effortlessly compare the experience of our managed SaaS versus our on-premises package it keeps our pricing honest.
+
+## Alternatives
+
+> Of course, this [assertion] section will be incorrect. You will make assertions that won’t pan out. You’ll miss budgets and deadlines and sales. So the alternatives section tells me what you’ll do if that happens. How much flexibility does your product or team have? If your assertions don’t pan out, is it over?
+
+Matrix is hard at work aligning its custom protocol with the emerging internet standards of group messaging, [MLS](https://datatracker.ietf.org/wg/mls/about/) and [MIMI](https://datatracker.ietf.org/wg/mimi/about/). Regardless of Commune's current design, we are aligning ourselves with a web-scale standard with which we can pivot to new markets as they emerge.
+
+## People
+
+> The people section rightly highlights the key element… who is on your team, who is going to join your team. ‘Who’ doesn’t mean their resume, who means their attitudes and abilities and track record in shipping.
+
+WIP
+
+## Money
+
+> And the last section is all about money. How much do you need, how will you spend it, what does cash flow look like, P&Ls, balance sheets, margins and exit strategies.
+
+WIP

--- a/src/routes/docs/quick-start/+page.md
+++ b/src/routes/docs/quick-start/+page.md
@@ -1,62 +1,38 @@
 ---
-title: Quick Start
+title: Terminology
 ---
 
-## Creating a project
+For clarity on technical vs user-facing terms in Commune.
 
-Run one of the following command  
-Depend on what package manager you are using
+### Spaces
 
-@install-pkg(@sveltepress,create)
+Every new community instance in Commune starts out as a new `space`, exactly equivalent to [Matrix Spaces](https://element.io/blog/spaces-the-next-frontier/). Unlike Matrix/Element however which allows for rooms (channels) to be created without a `space` container, Commune *requires* each new community to begin with a `space`containing at minimum one channel. We believe this is more in line with conventional group-messaging UX, such as Discord's 'servers' and Slack's 'workspaces'.
 
-:::tip[PNPM first]
-Use pnpm as much as possible. It respects package version more than npm.
-:::
+### Channels
 
-## Adding to an existing sveltekit project
+`channels` in Commune are the technical equivalent of `[rooms](https://spec.matrix.org/v1.8/rooms/)` in Matrix.
 
-### Install vite plugin package
+We opted for the `channel` term because of its mainstream use in chat platforms like [Slack](https://slack.com/features/channels), [Discord](https://discord.com/developers/docs/resources/channel) and [Microsoft Teams](https://learn.microsoft.com/en-us/microsoftteams/teams-channels-overview).
 
-@install-pkg(@sveltepress/vite)
+Similar concepts:
 
-### Replace `sveltekit` plugin in vite.config.(js|ts)
+- Fediverse: [Groups](https://codeberg.org/fediverse/fep/src/branch/main/fep/1b12/fep-1b12.md) 
+Partial compatibility is planned, e.g. by enabling an Announcements category to be federated.
 
-```js title="vite.config.(js|ts)"
-import { defineConfig } from 'vite'
+- Discourse: [Categories](https://meta.discourse.org/t/create-a-category-in-discourse/197224)
+Effectively the same as channels, except Discourse treats topics-board channels and chat-room channels as two separate containers, whereas in Commune each channel contains and is capable of both.
 
-import { sveltekit } from '@sveltejs/kit' // [svp! --]
+### Boards and view-modes
 
-import { sveltepress } from '@sveltepress/vite' // [svp! ++]
+`boards` are a novel concept in Commune compared to conventional group-messaging designs. Every channel in Commune can be viewed in two different modes:
 
-const config = defineConfig({
-  plugins: [
-    sveltekit(), // [svp! --]
-    sveltepress(), // [svp! ++]
-  ],
-})
+- Chat-view
+- Board-view
 
-export default config
-```
+Chat-view works like any other group chat. Board-view on the other hand presents a threads-centric view of the channel, in the tabulated style of an "[internet forum or message board](https://en.wikipedia.org/wiki/Internet_forum)".
 
-### Add `'.md'` extension to the `extensions` options in your svelte.config.js
+Channels intended strictly for asynchronous discourse in the form of threads can opt to disable the chat-view altogether and only allow thread posting.
 
-```js title="svelte.config.js"
-import adapter from '@sveltejs/adapter-static'
-import { vitePreprocess } from '@sveltejs/kit/vite'
+### Threads
 
-/**
- * @type {import('@sveltejs/kit').Config}
- */
-const config = {
-  extensions: ['.svelte'], // [svp! --]
-  extensions: ['.svelte', '.md'], // add .md here // [svp! ++]
-  preprocess: [vitePreprocess()],
-  kit: {
-    adapter: adapter({
-      pages: 'dist',
-    }),
-  },
-}
-
-export default config
-```
+`threads` in Commune are the same as `[threads](https://spec.matrix.org/v1.8/client-server-api/#threading)` in Matrix. However, Commune makes `threads` web-readable and thus SEO-friendly.


### PR DESCRIPTION
Just needs the quick-start folder to be renamed to 'terminology', which I can't do from the GitHub web UI.