### PR TITLE
chore: ci workflow to deploy staging

### DIFF
--- a/.github/workflows/deploy_draft.yml
+++ b/.github/workflows/deploy_draft.yml
@@ -1,0 +1,40 @@
+name: Deploy Draft
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      deployments: write
+    name: Publish
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3.0.2
+        with:
+          ref: 'main'
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v1
+        with:
+          bun-version: latest
+
+      - name: Install Dependencies
+        run: bun i
+
+      - name: Build Check
+        env:
+          NODE_ENV: production
+        run: bun run build
+
+      - name: Publish to Cloudflare Pages
+        uses: cloudflare/pages-action@1.0.0
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CF_ACCOUNT_ID }}
+          projectName: 'DRAFT_ENVIRONMENT_NAME'
+          directory: ./.svelte-kit/cloudflare
+          gitHubToken: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Provides a GitHub Actions Workflow to Publish the website to `draft` environment on every
commit made on `main`.

Observations:

- Bun is used in this script, this is done basically because Im reusing the script from my [personal website here](https://github.com/EstebanBorai/estebanborai.com/blob/main/.github/workflows/deploy-staging.yml). I think it would speed up CI process a lot given that you may want to use this against: https://github.com/commune-os/website/pull/4
- The adapter here: https://github.com/palyzambrano/commune.sh/blob/d300f0315ac96e801acc24e9d17fb455979151b0/svelte.config.js#L1 should use Cloudflare Pages Adapter instead.
- The Pages Project should be created on Cloudflare. You may want to upload contents from `./.svelte-kit/cloudflare` by building https://github.com/commune-os/website/pull/4. The name provided to such project should be replaced with: `'DRAFT_ENVIRONMENT_NAME'`.
- Setup a secret `CLOUDFLARE_API_TOKEN` with publish to Pages priviledges
- Setup a secret `CF_ACCOUNT_ID` with Cloudflare's Account ID
- `GITHUB_TOKEN` comes as part of the de-facto GH Actions environment, no need to do extra steps there